### PR TITLE
Catch error when trying to deliver non-stock items

### DIFF
--- a/shipment_management/public/js/custom_script.js
+++ b/shipment_management/public/js/custom_script.js
@@ -13,8 +13,8 @@ frappe.ui.form.on("Delivery Note", {
                                 frm.doc.items = r.message;
                                 create_dialog(frm);
                             } else {
-                                frappe.throw(__(`None of the items are deliverable. Please mark an Item
-                                    to "Manage Stock" and start delivering them.`))
+                                frappe.throw(__(`None of the items are deliverable. Please enable
+                                    "Maintain Stock" for Items to be able to deliver them.`))
                             }
                         }
                     })


### PR DESCRIPTION
When trying to deliver an item which doesn't have "Manage Stock" checked:

![image](https://user-images.githubusercontent.com/13396535/49423192-9a556480-f7bc-11e8-9675-d9720485c3ea.png)