### PR TITLE
fix: return empty rates rather than throwing

### DIFF
--- a/shipment_management/shipengine/api.py
+++ b/shipment_management/shipengine/api.py
@@ -153,7 +153,7 @@ def get_shipengine_rates(from_address, to_address, items=None, doc=None, estimat
 
 	# process all the returned rates
 	if not rates:
-		frappe.throw("Could not get rates, please re-check your shipping address.")
+		return []
 
 	shipping_rates = []
 	for rate in rates:


### PR DESCRIPTION
- If rates are returned as empty if custom_items in API call are None, then system throws an error, which should have been bypassed and returned as is.
