### PR TITLE
fix: ship estimate using old net_weight field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ latest_updates.json
 *.egg-info
 dist/
 erpnext/docs/current
+__pycache__


### PR DESCRIPTION
changes:
- drops using net_weight for new weight_per_unit field
- adds package and charges field to get_rate api for debug purposes 